### PR TITLE
Test Groq connections without a default model

### DIFF
--- a/__tests__/lib/groq-provider.test.ts
+++ b/__tests__/lib/groq-provider.test.ts
@@ -1,0 +1,65 @@
+import { jest } from '@jest/globals';
+
+const mockCreate = jest.fn();
+
+jest.mock('groq-sdk', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+  })),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { GroqProvider } from '@/lib/llm-providers/groq';
+
+describe('GroqProvider', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockCreate.mockReset();
+  });
+
+  it('verifies connections through the models endpoint without using a default chat model', async () => {
+    const mockFetch = jest.fn(async () => ({ ok: true }) as Response);
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const provider = new GroqProvider({
+      provider: 'groq',
+      apiKey: 'test-key',
+    });
+
+    const result = await provider.testConnection();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.groq.com/openai/v1/models',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-key',
+        }),
+      }),
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the models endpoint rejects the API key', async () => {
+    const mockFetch = jest.fn(async () => ({ ok: false, status: 401 }) as Response);
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const provider = new GroqProvider({
+      provider: 'groq',
+      apiKey: 'test-key',
+    });
+
+    await expect(provider.testConnection()).resolves.toBe(false);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,16 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        diagnostics: false,
+        tsconfig: 'tsconfig.json',
+      },
+    ],
+  },
+};

--- a/src/lib/llm-providers/groq.ts
+++ b/src/lib/llm-providers/groq.ts
@@ -4,6 +4,15 @@ import { BaseProvider } from '../llm-base-provider';
 import { LLMConfig } from '../llm-types';
 import { DEFAULT_MODELS } from '../llm-types';
 
+interface GroqModelResponse {
+    data?: Array<{
+        id: string;
+        context_window?: number;
+        owned_by: string;
+        active: boolean;
+    }>;
+}
+
 export class GroqProvider extends BaseProvider {
     private client: Groq;
     private apiKey: string;
@@ -37,8 +46,14 @@ export class GroqProvider extends BaseProvider {
 
     async testConnection(): Promise<boolean> {
         try {
-            await this.generateText('Hello', 'You are a helpful assistant.');
-            return true;
+            const response = await fetch('https://api.groq.com/openai/v1/models', {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${this.apiKey}`,
+                    'Content-Type': 'application/json',
+                },
+            });
+            return response.ok;
         } catch (error) {
             logger.error('Groq connection test failed', { error });
             return false;
@@ -99,9 +114,9 @@ export class GroqProvider extends BaseProvider {
                 throw new Error(`Groq API error: ${response.status}`);
             }
 
-            const data = await response.json();
+            const data = await response.json() as GroqModelResponse;
             
-            return data.data?.map((model: any) => ({
+            return data.data?.map((model) => ({
                 id: model.id,
                 name: GroqProvider.formatModelName(model.id),
                 contextWindow: model.context_window || 8192,


### PR DESCRIPTION
## Summary
- make Groq `testConnection()` validate the API key through `GET /openai/v1/models` instead of a chat completion
- avoid coupling provider setup to `DEFAULT_MODELS.groq`, so a delisted default model no longer blocks adding Groq
- add Groq provider regression tests and a minimal Jest config for the existing TypeScript test suite
- type the Groq model-list response while touching the provider file

Fixes #48.

## Verification
- `npx jest __tests__/lib/groq-provider.test.ts __tests__/lib/gemini-provider.test.ts --runInBand`
- `npx eslint src/lib/llm-providers/groq.ts __tests__/lib/groq-provider.test.ts jest.config.cjs`
- `git diff --check`

Notes:
- `npm run typecheck` still fails on existing unrelated strict test/mock and Prisma generated-type issues; none of the filtered errors mention `groq-provider`, `llm-providers/groq`, or `jest.config` after this change.
- `npm run lint` still fails on existing unrelated lint violations across tests and app files; touched-file ESLint passes.
